### PR TITLE
Support new Dalamud ImGui Bindings

### DIFF
--- a/PunishLib/AboutPlugin.cs
+++ b/PunishLib/AboutPlugin.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Interface;
 using Dalamud.Interface.Colors;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using PunishLib.ImGuiMethods;
 using System;
 using System.Collections.Generic;

--- a/PunishLib/GenericHelpers.cs
+++ b/PunishLib/GenericHelpers.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Logging;
 using ECommons.DalamudServices;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/PunishLib/ImGuiMethods/AboutTab.cs
+++ b/PunishLib/ImGuiMethods/AboutTab.cs
@@ -14,7 +14,7 @@ using ECommons.ImGuiMethods;
 //using ECommons;
 //using ECommons.DalamudServices;
 //using ECommons.Reflection;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -57,7 +57,7 @@ namespace PunishLib.ImGuiMethods
             {
                 if (ThreadLoadImageHandler.TryGetTextureWrap(GetImageURL(), out var texture))
                 {
-                    ImGui.Image(texture.ImGuiHandle, new(200f, 200f));
+                    ImGui.Image(texture.Handle, new(200f, 200f));
                 }
             });
             ImGuiHelpers.ScaledDummy(10f);

--- a/PunishLib/ImGuiMethods/IconButtons.cs
+++ b/PunishLib/ImGuiMethods/IconButtons.cs
@@ -1,5 +1,5 @@
 using Dalamud.Interface;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System.Numerics;
 
 namespace PunishLib.ImGuiMethods

--- a/PunishLib/ImGuiMethods/ImGuiEx.cs
+++ b/PunishLib/ImGuiMethods/ImGuiEx.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/PunishLib/ImGuiMethods/ImGuiGroup.cs
+++ b/PunishLib/ImGuiMethods/ImGuiGroup.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+﻿using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/PunishLib/ImGuiMethods/ImageLoadingResult.cs
+++ b/PunishLib/ImGuiMethods/ImageLoadingResult.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Interface.Internal;
 using Dalamud.Interface.Textures.TextureWraps;
-using ImGuiScene;
 
 namespace PunishLib.ImGuiMethods;
 

--- a/PunishLib/ImGuiMethods/InfoBox.cs
+++ b/PunishLib/ImGuiMethods/InfoBox.cs
@@ -1,6 +1,6 @@
 ﻿using Dalamud.Interface.Colors;
 using Dalamud.Interface;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/PunishLib/PunishLib.csproj
+++ b/PunishLib/PunishLib.csproj
@@ -40,14 +40,20 @@
             <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="ImGui.NET">
-            <HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="ImGuiScene">
-            <HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
+<Reference Remove="ImGui.NET" />
+<Reference Remove="ImGuiScene" />
+<Reference Include="Dalamud.Bindings.ImGui">
+    <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGui.dll</HintPath>
+    <Private>False</Private>
+</Reference>
+<Reference Include="Dalamud.Bindings.ImPlot">
+    <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImPlot.dll</HintPath>
+    <Private>False</Private>
+</Reference>
+<Reference Include="Dalamud.Bindings.ImGuizmo">
+    <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGuizmo.dll</HintPath>
+    <Private>False</Private>
+</Reference>
         <Reference Include="Lumina">
             <HintPath>$(DalamudLibPath)Lumina.dll</HintPath>
             <Private>False</Private>

--- a/PunishLib/PunishLib.csproj
+++ b/PunishLib/PunishLib.csproj
@@ -40,20 +40,20 @@
             <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
             <Private>False</Private>
         </Reference>
-<Reference Remove="ImGui.NET" />
-<Reference Remove="ImGuiScene" />
-<Reference Include="Dalamud.Bindings.ImGui">
-    <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGui.dll</HintPath>
-    <Private>False</Private>
-</Reference>
-<Reference Include="Dalamud.Bindings.ImPlot">
-    <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImPlot.dll</HintPath>
-    <Private>False</Private>
-</Reference>
-<Reference Include="Dalamud.Bindings.ImGuizmo">
-    <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGuizmo.dll</HintPath>
-    <Private>False</Private>
-</Reference>
+        <Reference Remove="ImGui.NET" />
+        <Reference Remove="ImGuiScene" />
+        <Reference Include="Dalamud.Bindings.ImGui">
+            <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGui.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Dalamud.Bindings.ImPlot">
+            <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImPlot.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Dalamud.Bindings.ImGuizmo">
+            <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGuizmo.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
         <Reference Include="Lumina">
             <HintPath>$(DalamudLibPath)Lumina.dll</HintPath>
             <Private>False</Private>

--- a/PunishLib/PunishLib.csproj
+++ b/PunishLib/PunishLib.csproj
@@ -40,8 +40,6 @@
             <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Remove="ImGui.NET" />
-        <Reference Remove="ImGuiScene" />
         <Reference Include="Dalamud.Bindings.ImGui">
             <HintPath>$(DalamudLibPath)Dalamud.Bindings.ImGui.dll</HintPath>
             <Private>False</Private>


### PR DESCRIPTION
- [X] Switches all references to `ImGuiNET` with `Dalamud.Bindings.ImGui`
- [X] Switches all `IDalamudTextureWrap` `ImGuiHandle` references to just `Handle`
- [X] Switches Project to include references to the new bindings, and remove the old

> [!NOTE]
> Drafted until this can actually be tested against the beta/release branch, but does work on the `imgui-bindings` branch.